### PR TITLE
Use all tags when creating name.

### DIFF
--- a/gen_version_h.ps1
+++ b/gen_version_h.ps1
@@ -5,7 +5,7 @@ param (
 $output_file = "${output_dir}version.h"
 
 # See if we actually need to update version.h
-$intended_ver = "#define GIT_VERSION_STRING `"$(git describe --always --dirty)`""
+$intended_ver = "#define GIT_VERSION_STRING `"$(git describe --tag --always --dirty)`""
 if (Test-Path -Path $output_file)
 {
     $current_ver = Get-Content -Path "$output_file" -Tail 1


### PR DESCRIPTION
Github doesn't use annotated tags which is not standard practice.

Fixes #43