### PR TITLE
Add better handling for 'show' for system error tab.

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,0 +1,9 @@
+﻿# Change log
+
+## 1.0.1
+
+Added the ability to display error details. If you double click an entry in the system errors tab, a new notepad buffer will be created containing the command that was run and any output or error output. Fixes #26, #50
+
+## 1.0.0
+
+Initial release

--- a/Changes.md
+++ b/Changes.md
@@ -1,8 +1,15 @@
-﻿# Change log
+# Change log
 
 ## 1.0.1
 
-Added the ability to display error details. If you double click an entry in the system errors tab, a new notepad buffer will be created containing the command that was run and any output or error output. Fixes #26, #50
+Added the ability to display error details. If you double click an entry in the system errors tab, either:
+
+1. If the error was in parsing linter++.xml, it will be opened and the cursor set to the posiion of the error. Fixes #26.
+1. otherwise, a new notepad buffer will be created containing the command that was run and any output or error output. Fixes #50
+
+This probably fixes a few issues where the extension could hang or decide it had received no output, as I completely rewrote the code that received output from the linter.
+
+Fixed an issue where the first file was taking a long time to process (see #13).
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ This is a fork of the 'linter' plugin for notepad++ from deadem which provides r
 ![Dockable error window](/img/2.png?raw=true)
 
 ## Installation
-
 - See <https://npp-user-manual.org/docs/plugins/>
 - Use the plugin manager. No, seriously.
 - If you must install manually, run notepad++ in administrator mode and
@@ -38,7 +37,7 @@ A note: Please don't supply empty sections, as this will become an error in the 
 
 You can control all the various settings for a scintilla indicator here. Your xml will look something like this:
 
-``` xml
+```
 <indicator>
   <colour>
     <shade>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A note: Please don't supply empty sections, as this will become an error in the 
 
 You can control all the various settings for a scintilla indicator here. Your xml will look something like this:
 
-```
+```xml
 <indicator>
   <colour>
     <shade>
@@ -52,7 +52,7 @@ You can control all the various settings for a scintilla indicator here. Your xm
   <draw_under/>
   <hover>
     <style>box</style>
-    <colour> <red>20</red> <green>20</green> <blue>250</blue> </colour> 
+    <colour> <red>20</red> <green>20</green> <blue>250</blue> </colour>
   </hover>
 </indicator>
 ```
@@ -105,8 +105,8 @@ For instance, you may wish to use eslint, jscs and jshint on all files with .js 
 
 ```xml
 <linters>
-  <linter>  
-    <extensions> 
+  <linter>
+    <extensions>
      <extension>.js</extension>
      <extension>.jsm</extension>
     </extensions>
@@ -158,7 +158,7 @@ If you don't specify `%LINTER_TARGET%` or `%%` in your `<args>` element, it is a
 Putting all those together, we get this:
 
 ```xml
-<?xml version="1.0" encoding="utf-8" ?> 
+<?xml version="1.0" encoding="utf-8" ?>
 <LinterPP>
   <indicator>
     <colour>
@@ -173,23 +173,23 @@ Putting all those together, we get this:
     <outline_opacity>255</outline_opacity>
     <draw_under/>
   </indicator>
-  
+
   <messages>
     <default> <red>0</red> <green>255</green> <blue>255</blue> </default>
     <error> <red>255</red> <green>0</green> <blue>0</blue> </error>
     <warning> <red>127</red> <green>127</green> <blue>0</blue> </warning>
   </messages>
- 
+
   <shortcuts>
     <edit><alt/><ctrl/><key>F5</key></edit>
     <show><shift/><ctrl/><key>F6</key></show>
     <previous><ctrl/><key>F7</key></previous>
     <next>><key>F8</key></next>
   </shortcuts>
-  
+
   <linters>
-    <linter>  
-      <extensions> 
+    <linter>
+      <extensions>
        <extension>.js</extension>
        <extension>.jsm</extension>
       </extensions>

--- a/linter.vcxproj
+++ b/linter.vcxproj
@@ -506,6 +506,7 @@ powershell.exe -File "$(ProjectDir)gen_version_h.ps1" "$(IntDir)\"</Command>
     <ClInclude Include="src\Dom_Node.h" />
     <ClInclude Include="src\Dom_Node_List.h" />
     <ClInclude Include="src\encoding.h" />
+    <ClInclude Include="src\Error_Info.h" />
     <ClInclude Include="src\File_Holder.h" />
     <ClInclude Include="src\Child_Pipe.h" />
     <ClInclude Include="src\Handle_Wrapper.h" />

--- a/linter.vcxproj
+++ b/linter.vcxproj
@@ -539,6 +539,10 @@ powershell.exe -File "$(ProjectDir)gen_version_h.ps1" "$(IntDir)\"</Command>
     <None Include=".github\workflows\CI_pull_request.yml" />
     <None Include=".github\workflows\CI_release.yml" />
     <None Include=".github\workflows\codeql-analysis.yml" />
+    <None Include="Changes.md">
+      <SubType>
+      </SubType>
+    </None>
     <None Include="gen_version_h.ps1" />
     <None Include="iwyu.bat" />
     <None Include="post-build.ps1" />

--- a/linter.vcxproj.filters
+++ b/linter.vcxproj.filters
@@ -234,6 +234,7 @@
       <Filter>Github\Workflows</Filter>
     </None>
     <None Include="PSScriptAnalyzerSettings.psd1" />
+    <None Include="Changes.md" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="src\linter.ico">

--- a/linter.vcxproj.filters
+++ b/linter.vcxproj.filters
@@ -202,6 +202,9 @@
     <ClInclude Include="src\Indicator.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\Error_Info.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="src\Resource.rc">

--- a/src/CheckStyle_Parser.cpp
+++ b/src/CheckStyle_Parser.cpp
@@ -3,6 +3,7 @@
 #include "Dom_Document.h"
 #include "Dom_Node.h"
 #include "Dom_Node_List.h"
+#include "Error_Info.h"
 
 #include <cstddef>
 #include <string>
@@ -11,7 +12,7 @@
 namespace Linter
 {
 
-std::vector<Checkstyle_Parser::Error> Checkstyle_Parser::get_errors(
+std::vector<Error_Info> Checkstyle_Parser::get_errors(
     std::string const &xml
 )
 {
@@ -32,7 +33,7 @@ std::vector<Checkstyle_Parser::Error> Checkstyle_Parser::get_errors(
     //
     // We use the 1st word in source as the tool.
 
-    std::vector<Checkstyle_Parser::Error> errors;
+    std::vector<Error_Info> errors;
 
     Dom_Node_List nodes(document.get_node_list("//error"));
     for (auto const node : nodes)
@@ -44,7 +45,8 @@ std::vector<Checkstyle_Parser::Error> Checkstyle_Parser::get_errors(
             tool.resize(pos);
         }
 
-        errors.push_back(Error{
+        errors.push_back(Error_Info{
+            .mode_ = Error_Info::Standard,
             .line_ = std::stoi(node.get_attribute(L"line")),
             .column_ = std::stoi(node.get_attribute(L"column")),
             .message_ = node.get_attribute(L"message"),

--- a/src/CheckStyle_Parser.cpp
+++ b/src/CheckStyle_Parser.cpp
@@ -12,9 +12,7 @@
 namespace Linter
 {
 
-std::vector<Error_Info> Checkstyle_Parser::get_errors(
-    std::string const &xml
-)
+std::vector<Error_Info> Checkstyle_Parser::get_errors(std::string const &xml)
 {
     Dom_Document document{xml};
 
@@ -46,12 +44,12 @@ std::vector<Error_Info> Checkstyle_Parser::get_errors(
         }
 
         errors.push_back(Error_Info{
-            .mode_ = Error_Info::Standard,
-            .line_ = std::stoi(node.get_attribute(L"line")),
-            .column_ = std::stoi(node.get_attribute(L"column")),
             .message_ = node.get_attribute(L"message"),
             .severity_ = node.get_attribute(L"severity"),
-            .tool_ = tool
+            .tool_ = tool,
+            .mode_ = Error_Info::Standard,
+            .line_ = std::stoi(node.get_attribute(L"line")),
+            .column_ = std::stoi(node.get_attribute(L"column"))
         });
     }
 

--- a/src/Checkstyle_Parser.h
+++ b/src/Checkstyle_Parser.h
@@ -6,19 +6,12 @@
 namespace Linter
 {
 
+struct Error_Info;
+
 class Checkstyle_Parser
 {
   public:
-    struct Error
-    {
-        int line_;
-        int column_;
-        std::wstring message_;
-        std::wstring severity_;
-        std::wstring tool_;
-    };
-
-    static std::vector<Error> get_errors(std::string const &xml);
+    static std::vector<Error_Info> get_errors(std::string const &xml);
 };
 
 }    // namespace Linter

--- a/src/Child_Pipe.cpp
+++ b/src/Child_Pipe.cpp
@@ -37,21 +37,29 @@ Child_Pipe Child_Pipe::create_output_pipe()
 }
 
 std::pair<std::string, std::string> Child_Pipe::read_output_pipes(
-    Child_Pipe const &pipe1, Child_Pipe const &pipe2
+    HANDLE process, Child_Pipe const &pipe1, Child_Pipe const &pipe2
 )
 {
-    std::string res1;
-    std::string res2;
-
     constexpr DWORD BUFFSIZE = 0x4000;
     std::vector<char> buffer;
     buffer.resize(BUFFSIZE);
     auto const buff{&*buffer.begin()};
 
+    std::string res1;
+    std::string res2;
+
     bool more_to_read = true;
     while (more_to_read)
     {
         more_to_read = false;
+
+        auto const state = WaitForSingleObject(process, 50);
+        if (state == WAIT_FAILED)
+        {
+            throw System_Error();
+        }
+
+        more_to_read = state == WAIT_TIMEOUT;
 
         DWORD bytes_avail = 0;
         if (not PeekNamedPipe(
@@ -67,7 +75,11 @@ std::pair<std::string, std::string> Child_Pipe::read_output_pipes(
         if (bytes_avail != 0)
         {
             if (not ReadFile(
-                    pipe1.reader(), buff, BUFFSIZE, &bytes_avail, NULL
+                    pipe1.reader(),
+                    buff,
+                    std::min(BUFFSIZE, bytes_avail),
+                    &bytes_avail,
+                    NULL
                 ))
             {
                 throw System_Error();
@@ -89,7 +101,11 @@ std::pair<std::string, std::string> Child_Pipe::read_output_pipes(
         if (bytes_avail != 0)
         {
             if (not ReadFile(
-                    pipe2.reader(), buff, BUFFSIZE, &bytes_avail, NULL
+                    pipe2.reader(),
+                    buff,
+                    std::min(BUFFSIZE, bytes_avail),
+                    &bytes_avail,
+                    NULL
                 ))
             {
                 throw System_Error();
@@ -98,7 +114,6 @@ std::pair<std::string, std::string> Child_Pipe::read_output_pipes(
             more_to_read = true;
         }
     }
-
     return std::make_pair(res1, res2);
 }
 

--- a/src/Child_Pipe.cpp
+++ b/src/Child_Pipe.cpp
@@ -3,12 +3,21 @@
 #include "Handle_Wrapper.h"
 #include "System_Error.h"
 
+#include <errhandlingapi.h>
+#include <fileapi.h>
 #include <handleapi.h>
+#include <intsafe.h>
 #include <minwinbase.h>
 #include <minwindef.h>
 #include <namedpipeapi.h>
 #include <winbase.h>
 #include <winnt.h>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <stddef.h>
 
 namespace Linter
 {
@@ -25,6 +34,72 @@ Child_Pipe Child_Pipe::create_output_pipe()
     Child_Pipe pipe;
     detach(pipe.pipes_.reader_);
     return pipe;
+}
+
+std::pair<std::string, std::string> Child_Pipe::read_output_pipes(
+    Child_Pipe const &pipe1, Child_Pipe const &pipe2
+)
+{
+    std::string res1;
+    std::string res2;
+
+    constexpr DWORD BUFFSIZE = 0x4000;
+    std::vector<char> buffer;
+    buffer.resize(BUFFSIZE);
+    auto const buff{&*buffer.begin()};
+
+    bool more_to_read = true;
+    while (more_to_read)
+    {
+        more_to_read = false;
+
+        DWORD bytes_avail = 0;
+        if (not PeekNamedPipe(
+                pipe1.reader(), NULL, 0, NULL, &bytes_avail, NULL
+            ))
+        {
+            DWORD const err = GetLastError();
+            if (err != ERROR_BROKEN_PIPE)
+            {
+                throw System_Error(err);
+            }
+        }
+        if (bytes_avail != 0)
+        {
+            if (not ReadFile(
+                    pipe1.reader(), buff, BUFFSIZE, &bytes_avail, NULL
+                ))
+            {
+                throw System_Error();
+            }
+            res1.append(buff, bytes_avail);
+            more_to_read = true;
+        }
+        bytes_avail = 0;
+        if (not PeekNamedPipe(
+                pipe2.reader(), NULL, 0, NULL, &bytes_avail, NULL
+            ))
+        {
+            DWORD const err = GetLastError();
+            if (err != ERROR_BROKEN_PIPE)
+            {
+                throw System_Error(err);
+            }
+        }
+        if (bytes_avail != 0)
+        {
+            if (not ReadFile(
+                    pipe2.reader(), buff, BUFFSIZE, &bytes_avail, NULL
+                ))
+            {
+                throw System_Error();
+            }
+            res2.append(buff, bytes_avail);
+            more_to_read = true;
+        }
+    }
+
+    return std::make_pair(res1, res2);
 }
 
 #pragma warning(suppress : 26455)

--- a/src/Child_Pipe.h
+++ b/src/Child_Pipe.h
@@ -2,6 +2,9 @@
 
 #include "Handle_Wrapper.h"
 
+#include <string>
+#include <utility>
+
 namespace Linter
 {
 
@@ -20,6 +23,10 @@ class Child_Pipe
 
     static Child_Pipe create_output_pipe();
     static Child_Pipe create_input_pipe();
+
+    static std::pair<std::string, std::string> read_output_pipes(
+        Child_Pipe const &pipe1, Child_Pipe const &pipe2
+    );
 
   private:
     struct Pipes

--- a/src/Child_Pipe.h
+++ b/src/Child_Pipe.h
@@ -25,7 +25,7 @@ class Child_Pipe
     static Child_Pipe create_input_pipe();
 
     static std::pair<std::string, std::string> read_output_pipes(
-        Child_Pipe const &pipe1, Child_Pipe const &pipe2
+        HANDLE process, Child_Pipe const &pipe1, Child_Pipe const &pipe2
     );
 
   private:

--- a/src/Child_Pipe.h
+++ b/src/Child_Pipe.h
@@ -2,6 +2,8 @@
 
 #include "Handle_Wrapper.h"
 
+#include <winnt.h>
+
 #include <string>
 #include <utility>
 

--- a/src/Dom_Document.cpp
+++ b/src/Dom_Document.cpp
@@ -32,7 +32,7 @@ Linter::Dom_Document::Dom_Document(
 
     // Assign the schema cache to the DOMDocument's schemas collection.
     HRESULT hr = document_->putref_schemas(CComVariant(schemas));
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't use schema collection");
     }
@@ -62,7 +62,7 @@ Dom_Node_List Dom_Document::get_node_list(std::string const &xpath) const
     CComPtr<IXMLDOMNodeList> nodes;
     HRESULT const hr =
         document_->selectNodes(static_cast<_bstr_t>(xpath.c_str()), &nodes);
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't execute XPath " + xpath);
     }
@@ -74,7 +74,7 @@ std::optional<Dom_Node> Dom_Document::get_node(std::string const &xpath) const
     CComPtr<IXMLDOMNode> node;
     HRESULT const hr =
         document_->selectSingleNode(static_cast<_bstr_t>(xpath.c_str()), &node);
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't execute XPath " + xpath);
     }
@@ -88,13 +88,13 @@ std::optional<Dom_Node> Dom_Document::get_node(std::string const &xpath) const
 void Dom_Document::init()
 {
     HRESULT hr = document_.CoCreateInstance(__uuidof(DOMDocument60));
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't create IID_IXMLDOMDocument2");
     }
 
     hr = document_->put_async(VARIANT_FALSE);
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't XMLDOMDocument2::put_async");
     }
@@ -102,7 +102,7 @@ void Dom_Document::init()
 
 void Dom_Document::checkLoadResults(VARIANT_BOOL resultcode, HRESULT hr) const
 {
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr);
     }

--- a/src/Dom_Document.cpp
+++ b/src/Dom_Document.cpp
@@ -28,7 +28,7 @@ Linter::Dom_Document::Dom_Document(
 
     document_->put_validateOnParse(VARIANT_TRUE);
     // Not sure what this does but it doesn't seem to be  necessary.
-    // pXD->put_resolveExternals(VARIANT_TRUE); 
+    // pXD->put_resolveExternals(VARIANT_TRUE);
 
     // Assign the schema cache to the DOMDocument's schemas collection.
     HRESULT hr = document_->putref_schemas(CComVariant(schemas));

--- a/src/Dom_Node.cpp
+++ b/src/Dom_Node.cpp
@@ -23,7 +23,7 @@ Dom_Node_List Dom_Node::get_node_list(std::string const &xpath) const
     CComPtr<IXMLDOMNodeList> node_list;
     auto const hr =
         node_->selectNodes(static_cast<bstr_t>(xpath.c_str()), &node_list);
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't get node list from " + xpath);
     }
@@ -45,7 +45,7 @@ std::optional<Dom_Node> Dom_Node::get_optional_node(std::string const &xpath) co
     CComPtr<IXMLDOMNode> node;
     auto const hr =
         node_->selectSingleNode(static_cast<bstr_t>(xpath.c_str()), &node);
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't get node from xpath " + xpath);
     }
@@ -60,7 +60,7 @@ std::wstring Dom_Node::get_name() const
 {
     CComBSTR name;
     auto const hr = node_->get_nodeName(&name);
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't get node name");
     }
@@ -71,7 +71,7 @@ std::wstring Dom_Node::get_value() const
 {
     CComVariant res;
     auto const hr = node_->get_nodeTypedValue(&res);
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't get node value");
     }
@@ -85,7 +85,7 @@ std::wstring Dom_Node::get_attribute(std::wstring const &attribute) const
 
     auto const hr =
         element->getAttribute(static_cast<bstr_t>(attribute.c_str()), &value);
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't get node attribute value");
     }

--- a/src/Dom_Node.cpp
+++ b/src/Dom_Node.cpp
@@ -40,7 +40,8 @@ Dom_Node Dom_Node::get_node(std::string const &xpath) const
     return *node;
 }
 
-std::optional<Dom_Node> Dom_Node::get_optional_node(std::string const &xpath) const
+std::optional<Dom_Node> Dom_Node::get_optional_node(std::string const &xpath
+) const
 {
     CComPtr<IXMLDOMNode> node;
     auto const hr =

--- a/src/Dom_Node_List.cpp
+++ b/src/Dom_Node_List.cpp
@@ -20,7 +20,7 @@ Dom_Node Dom_Node_List::iterator::operator*() const
 {
     CComPtr<IXMLDOMNode> node;
     auto const hr = node_list_->get_item(item_, &node);
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't get item detail");
     }
@@ -31,7 +31,7 @@ Dom_Node_List::Dom_Node_List(CComPtr<IXMLDOMNodeList> node_list) :
     node_list_(node_list)
 {
     HRESULT const hr = node_list->get_length(&num_items_);
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't get number of items in node list");
     }

--- a/src/Error_Info.h
+++ b/src/Error_Info.h
@@ -22,6 +22,7 @@ struct Error_Info
     std::wstring severity_ = L"error";
     std::wstring tool_;
     std::wstring command_;
+    DWORD result_;
     std::string stdout_;
     std::string stderr_;
 };

--- a/src/Error_Info.h
+++ b/src/Error_Info.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <intsafe.h>
+
 #include <string>
 
 namespace Linter
@@ -15,16 +17,18 @@ struct Error_Info
         Stderr_Found,      // Information found in stderr
         Exception,         // Unexpected exception when processing file
         Other              // Other exception when processing
-    } mode_;
-    int line_ = 0;
-    int column_ = 0;
+    };
+
     std::wstring message_;
     std::wstring severity_ = L"error";
     std::wstring tool_;
     std::wstring command_;
-    DWORD result_;
     std::string stdout_;
     std::string stderr_;
+    Mode mode_;
+    int line_ = 0;
+    int column_ = 0;
+    DWORD result_;
 };
 
 }    // namespace Linter

--- a/src/Error_Info.h
+++ b/src/Error_Info.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+namespace Linter
+{
+
+struct Error_Info
+{
+    enum Mode
+    {
+        Standard,          // Detected by a linter
+        Bad_Linter_XML,    // Couldn't parse linter++.xml
+        Bad_Output,        // Couldn't parse linter output
+        Stderr_Found,      // Information found in stderr
+        Exception,         // Unexpected exception when processing file
+        Other              // Other exception when processing
+    } mode_;
+    int line_ = 0;
+    int column_ = 0;
+    std::wstring message_;
+    std::wstring severity_ = L"error";
+    std::wstring tool_;
+    std::wstring command_;
+    std::string stdout_;
+    std::string stderr_;
+};
+
+}    // namespace Linter

--- a/src/File_Holder.cpp
+++ b/src/File_Holder.cpp
@@ -147,7 +147,7 @@ void File_Holder::write(std::string const &data)
         0,
         nullptr,
         CREATE_ALWAYS,
-        FILE_ATTRIBUTE_HIDDEN,
+        FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_TEMPORARY,
         nullptr
     )};
 

--- a/src/File_Holder.cpp
+++ b/src/File_Holder.cpp
@@ -106,6 +106,9 @@ std::pair<std::string, std::string> File_Holder::exec(
     }
     stdin_pipe.writer().close();
 
+    // FIXME We really should create a thread to read the stdout and stderr, in
+    // case we get over 64k of output. This may fix the other problems below.
+
     // It does seem that for the first run of this, we don't actually get a
     // result till we change the buffer. Should possibly be using
     // WaitForSingleObject(proc_info.hProcess, INFINITE) somewhere here.

--- a/src/File_Holder.cpp
+++ b/src/File_Holder.cpp
@@ -103,7 +103,7 @@ std::tuple<std::wstring, DWORD, std::string, std::string> File_Holder::exec(
     if (command.use_stdin)
     {
         // FIXME Use WaitForInputIdle here?
-        stdin_pipe.writer().writeFile(text);
+        stdin_pipe.writer().write_file(text);
     }
     stdin_pipe.writer().close();
 
@@ -151,7 +151,7 @@ void File_Holder::write(std::string const &data)
         nullptr
     )};
 
-    handle.writeFile(data);
+    handle.write_file(data);
 }
 
 void File_Holder::setup_environment() const

--- a/src/File_Holder.cpp
+++ b/src/File_Holder.cpp
@@ -32,7 +32,7 @@ File_Holder::File_Holder(std::filesystem::path const &path) : path_(path)
 
 File_Holder::~File_Holder()
 {
-    if (! temp_file_.empty())
+    if (not temp_file_.empty())
     {
         std::error_code errcode;
         std::filesystem::remove(temp_file_, errcode);

--- a/src/File_Holder.cpp
+++ b/src/File_Holder.cpp
@@ -21,7 +21,7 @@
 #include <memory>
 #include <string>
 #include <system_error>
-#include <utility>
+#include <tuple>
 
 namespace Linter
 {
@@ -39,7 +39,7 @@ File_Holder::~File_Holder()
     }
 }
 
-std::pair<std::string, std::string> File_Holder::exec(
+std::tuple<std::wstring, std::string, std::string> File_Holder::exec(
     Settings::Linter::Command const &command, std::string const &text
 )
 {
@@ -128,7 +128,7 @@ std::pair<std::string, std::string> File_Holder::exec(
 
     std::string out = stdout_pipe.reader().readFile();
     std::string err = stderr_pipe.reader().readFile();
-    return std::make_pair(out, err);
+    return std::make_tuple(args, out, err);
 }
 
 void File_Holder::write(std::string const &data)

--- a/src/File_Holder.h
+++ b/src/File_Holder.h
@@ -22,7 +22,7 @@ class File_Holder
 
     ~File_Holder();
 
-    std::tuple<std::wstring, std::string, std::string> exec(
+    std::tuple<std::wstring, DWORD, std::string, std::string> exec(
         Settings::Linter::Command const &, std::string const &text
     );
 

--- a/src/File_Holder.h
+++ b/src/File_Holder.h
@@ -3,6 +3,8 @@
 // Fixme do we extract the command substructure somewhere?
 #include "Settings.h"
 
+#include <intsafe.h>
+
 #include <filesystem>
 #include <string>
 #include <tuple>

--- a/src/File_Holder.h
+++ b/src/File_Holder.h
@@ -5,7 +5,7 @@
 
 #include <filesystem>
 #include <string>
-#include <utility>
+#include <tuple>
 
 namespace Linter
 {
@@ -22,7 +22,7 @@ class File_Holder
 
     ~File_Holder();
 
-    std::pair<std::string, std::string> exec(
+    std::tuple<std::wstring, std::string, std::string> exec(
         Settings::Linter::Command const &, std::string const &text
     );
 

--- a/src/Handle_Wrapper.cpp
+++ b/src/Handle_Wrapper.cpp
@@ -2,16 +2,13 @@
 
 #include "System_Error.h"
 
-#include <errhandlingapi.h>
 #include <fileapi.h>
 #include <handleapi.h>
 #include <intsafe.h>
-#include <winerror.h>
 
 #include <cstddef>
 #include <limits>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace Linter
@@ -70,7 +67,7 @@ void Handle_Wrapper::writeFile(std::string const &str) const
     }
 }
 
-std::string Handle_Wrapper::readFile() const
+std::string Handle_Wrapper::read_file() const
 {
     std::string result;
 
@@ -82,27 +79,17 @@ std::string Handle_Wrapper::readFile() const
     for (;;)
     {
         DWORD bytes_read;
-        // The API suggests when the other end closes the pipe, you should get
-        // 0. What appears to happen is that you get broken pipe.
         if (! ReadFile(handle_, buff, BUFFSIZE, &bytes_read, nullptr))
         {
-            DWORD const err = GetLastError();
-            if (err != ERROR_BROKEN_PIPE)
-            {
-                throw System_Error(err);
-            }
+            throw System_Error();
         }
 
-        result.append(buff, bytes_read);
-
-        // Assume partial reads are EOF. Not sure this is ideal, but when
-        // reading from a pipe you can get random hangs if you attempt to read
-        // more.
-        if (bytes_read < BUFFSIZE)
+        if (bytes_read == 0)
         {
             break;
         }
 
+        result.append(buff, bytes_read);
     }
 
     return result;

--- a/src/Handle_Wrapper.cpp
+++ b/src/Handle_Wrapper.cpp
@@ -93,12 +93,16 @@ std::string Handle_Wrapper::readFile() const
             }
         }
 
-        if (bytes_read == 0)
+        result.append(buff, bytes_read);
+
+        // Assume partial reads are EOF. Not sure this is ideal, but when
+        // reading from a pipe you can get random hangs if you attempt to read
+        // more.
+        if (bytes_read < BUFFSIZE)
         {
             break;
         }
 
-        result.append(buff, bytes_read);
     }
 
     return result;

--- a/src/Handle_Wrapper.cpp
+++ b/src/Handle_Wrapper.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <limits>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace Linter
@@ -46,7 +47,7 @@ Handle_Wrapper::operator HANDLE() const noexcept
     return handle_;
 }
 
-void Handle_Wrapper::writeFile(std::string const &str) const
+void Handle_Wrapper::write_file(std::string const &str) const
 {
     auto start = str.begin();
     auto const end = str.end();

--- a/src/Handle_Wrapper.cpp
+++ b/src/Handle_Wrapper.cpp
@@ -48,8 +48,6 @@ Handle_Wrapper::operator HANDLE() const noexcept
 
 void Handle_Wrapper::writeFile(std::string const &str) const
 {
-    static_assert(sizeof(str[0]) == 1, "Invalid byte size");
-
     auto start = str.begin();
     auto const end = str.end();
     while (start != end)
@@ -59,7 +57,7 @@ void Handle_Wrapper::writeFile(std::string const &str) const
             end - start
         ));
         DWORD written;
-        if (! WriteFile(handle_, &*start, toWrite, &written, nullptr))
+        if (not WriteFile(handle_, &*start, toWrite, &written, nullptr))
         {
             throw System_Error();
         }
@@ -79,7 +77,7 @@ std::string Handle_Wrapper::read_file() const
     for (;;)
     {
         DWORD bytes_read;
-        if (! ReadFile(handle_, buff, BUFFSIZE, &bytes_read, nullptr))
+        if (not ReadFile(handle_, buff, BUFFSIZE, &bytes_read, nullptr))
         {
             throw System_Error();
         }

--- a/src/Handle_Wrapper.h
+++ b/src/Handle_Wrapper.h
@@ -3,7 +3,6 @@
 #include <winnt.h>    // For HANDLE
 
 #include <string>
-#include <utility>
 
 namespace Linter
 {
@@ -26,7 +25,7 @@ class Handle_Wrapper
      *
      * @param str - string to write
      */
-    void writeFile(std::string const &str) const;
+    void write_file(std::string const &str) const;
 
     /** Read the entire file
      *

--- a/src/Handle_Wrapper.h
+++ b/src/Handle_Wrapper.h
@@ -3,6 +3,7 @@
 #include <winnt.h>    // For HANDLE
 
 #include <string>
+#include <utility>
 
 namespace Linter
 {
@@ -27,8 +28,11 @@ class Handle_Wrapper
      */
     void writeFile(std::string const &str) const;
 
-    /** Read the entire file */
-    std::string readFile() const;
+    /** Read the entire file
+     *
+     * It is NOT advised to use this for stdout/stderr pipes.
+     */
+    std::string read_file() const;
 
   private:
     mutable HANDLE handle_;

--- a/src/Output_Dialogue.cpp
+++ b/src/Output_Dialogue.cpp
@@ -625,6 +625,8 @@ void Output_Dialogue::show_selected_lint(int selected_item) noexcept
                 )
                 + "\n\n"
             );
+            append_text_with_style("Return code:", style);
+            append_text(" " + std::to_string(lint_error.result_) + "\n\n");
             append_text_with_style("Output:", style);
             append_text("\n\n");
             line = static_cast<int>(plugin()->send_to_editor(

--- a/src/Output_Dialogue.h
+++ b/src/Output_Dialogue.h
@@ -44,10 +44,10 @@ class Output_Dialogue : protected Docking_Dialogue_Interface
     void clear_lint_info();
 
     /** Add an error to the system error list */
-    void add_system_error(Checkstyle_Parser::Error const &);
+    void add_system_error(Error_Info const &);
 
     /** Add a list of lint errors to the lint error list */
-    void add_lint_errors(std::vector<Checkstyle_Parser::Error> const &lints);
+    void add_lint_errors(std::vector<Error_Info> const &lints);
 
     /** Selects the next lint message */
     void select_next_lint() noexcept;
@@ -77,7 +77,7 @@ class Output_Dialogue : protected Docking_Dialogue_Interface
         UINT list_view_id;
         Tab tab;
         HWND list_view;
-        std::vector<Checkstyle_Parser::Error> errors;
+        std::vector<Error_Info> errors;
     };
 
     Message_Return on_dialogue_message(
@@ -113,7 +113,7 @@ class Output_Dialogue : protected Docking_Dialogue_Interface
 
     /** Add list of errors to the appropriate tab */
     void add_errors(
-        Tab tab, std::vector<Checkstyle_Parser::Error> const &lints
+        Tab tab, std::vector<Error_Info> const &lints
     );
 
     /** Skip to the n-th lint forward or backward */
@@ -121,6 +121,9 @@ class Output_Dialogue : protected Docking_Dialogue_Interface
 
     /** Move to the line/column of the displayed error */
     void show_selected_lint(int selected_item) noexcept;
+
+    /** Opens up a new window, displays command info */
+    void show_selected_detail(int selected_item) noexcept;
 
     /** Copy selected messages to clipboard */
     void copy_to_clipboard();

--- a/src/Output_Dialogue.h
+++ b/src/Output_Dialogue.h
@@ -112,9 +112,7 @@ class Output_Dialogue : protected Docking_Dialogue_Interface
     void update_displayed_counts();
 
     /** Add list of errors to the appropriate tab */
-    void add_errors(
-        Tab tab, std::vector<Error_Info> const &lints
-    );
+    void add_errors(Tab tab, std::vector<Error_Info> const &lints);
 
     /** Skip to the n-th lint forward or backward */
     void select_lint(int n) noexcept;
@@ -123,7 +121,8 @@ class Output_Dialogue : protected Docking_Dialogue_Interface
     void append_text(std::string_view text) const noexcept;
 
     /** Add underlined text to end of buffer */
-    void append_text_with_style(std::string_view text, int style) const noexcept;
+    void append_text_with_style(std::string_view text, int style)
+        const noexcept;
 
     /** Move to the line/column of the displayed error */
     void show_selected_lint(int selected_item) noexcept;

--- a/src/Output_Dialogue.h
+++ b/src/Output_Dialogue.h
@@ -119,6 +119,12 @@ class Output_Dialogue : protected Docking_Dialogue_Interface
     /** Skip to the n-th lint forward or backward */
     void select_lint(int n) noexcept;
 
+    /** Add text to end of buffer */
+    void append_text(std::string_view text) const noexcept;
+
+    /** Add underlined text to end of buffer */
+    void append_text_with_style(std::string_view text, int style) const noexcept;
+
     /** Move to the line/column of the displayed error */
     void show_selected_lint(int selected_item) noexcept;
 

--- a/src/Output_Dialogue.h
+++ b/src/Output_Dialogue.h
@@ -122,9 +122,6 @@ class Output_Dialogue : protected Docking_Dialogue_Interface
     /** Move to the line/column of the displayed error */
     void show_selected_lint(int selected_item) noexcept;
 
-    /** Opens up a new window, displays command info */
-    void show_selected_detail(int selected_item) noexcept;
-
     /** Copy selected messages to clipboard */
     void copy_to_clipboard();
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -55,15 +55,16 @@ Settings::Settings(::Linter::Linter const &linter) :
         throw System_Error(hr, "Can't add to schema pool");
     }
 
-    //A note: We try to read the settings at this point and quietly ignore errors
-    //if we can't. This isn't great, but not sure where I can put errors.
+    // A note: We try to read the settings at this point and quietly ignore
+    // errors if we can't. This isn't great, but not sure where I can put
+    // errors.
     try
     {
         refresh();
     }
-    catch (std::exception const&)
+    catch (std::exception const &)
     {
-        //Nothing we can usefully do.
+        // Nothing we can usefully do.
     }
 }
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -43,14 +43,14 @@ Settings::Settings(::Linter::Linter const &linter) :
 {
     // Create a schema cache and our xsd to it.
     auto hr = settings_schema_.CoCreateInstance(__uuidof(XMLSchemaCache60));
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't create XMLSchemaCache60");
     }
 
     CComVariant xsd{settings_xsd_.c_str()};
     hr = settings_schema_->add(bstr_t(""), xsd);
-    if (! SUCCEEDED(hr))
+    if (not SUCCEEDED(hr))
     {
         throw System_Error(hr, "Can't add to schema pool");
     }

--- a/src/linter.cpp
+++ b/src/linter.cpp
@@ -431,7 +431,7 @@ void Linter::apply_linters()
         try
         {
             // Try and work out what to do here:
-            auto const [cmdline, output, errout] = file.exec(command, text);
+            auto const [cmdline, result, output, errout] = file.exec(command, text);
             if (output.empty() && not errout.empty())
             {
                 // Program terminated with error.
@@ -440,6 +440,7 @@ void Linter::apply_linters()
                      .message_ = std::wstring(errout.begin(), errout.end()),
                      .tool_ = command.program.stem(),
                      .command_ = cmdline,
+                     .result_ = result,
                      .stdout_ = output,
                      .stderr_ = errout}
                 );

--- a/src/linter.cpp
+++ b/src/linter.cpp
@@ -353,10 +353,10 @@ unsigned int Linter::run_linter() noexcept
             std::string exc{e.what()};
             std::wstring wstr{exc.begin(), exc.end()};
             output_dialogue_->add_system_error(
-                {.mode_ = Error_Info::Bad_Linter_XML,
+                {.message_ = wstr,
+                 .mode_ = Error_Info::Bad_Linter_XML,
                  .line_ = e.line(),
-                 .column_ = e.column(),
-                 .message_ = wstr}
+                 .column_ = e.column()}
             );
             show_tooltip(wstr);
         }
@@ -365,7 +365,7 @@ unsigned int Linter::run_linter() noexcept
             std::string const exc(e.what());
             std::wstring wstr{exc.begin(), exc.end()};
             output_dialogue_->add_system_error(
-                {.mode_ = Error_Info::Exception, .message_ = wstr}
+                {.message_ = wstr, .mode_ = Error_Info::Exception}
             );
             show_tooltip(wstr);
         }
@@ -431,18 +431,19 @@ void Linter::apply_linters()
         try
         {
             // Try and work out what to do here:
-            auto const [cmdline, result, output, errout] = file.exec(command, text);
+            auto const [cmdline, result, output, errout] =
+                file.exec(command, text);
             if (output.empty() && not errout.empty())
             {
                 // Program terminated with error.
                 output_dialogue_->add_system_error(
-                    {.mode_ = Error_Info::Stderr_Found,
-                     .message_ = std::wstring(errout.begin(), errout.end()),
+                    {.message_ = std::wstring(errout.begin(), errout.end()),
                      .tool_ = command.program.stem(),
                      .command_ = cmdline,
-                     .result_ = result,
                      .stdout_ = output,
-                     .stderr_ = errout}
+                     .stderr_ = errout,
+                     .mode_ = Error_Info::Stderr_Found,
+                     .result_ = result}
                 );
                 continue;
             }
@@ -460,13 +461,13 @@ void Linter::apply_linters()
                 if (not errout.empty())
                 {
                     output_dialogue_->add_system_error(
-                        {.mode_ = Error_Info::Stderr_Found,
-                         .message_ = std::wstring(errout.begin(), errout.end()),
+                        {.message_ = std::wstring(errout.begin(), errout.end()),
                          .severity_ = L"warning",
                          .tool_ = command.program.stem(),
                          .command_ = cmdline,
                          .stdout_ = output,
-                         .stderr_ = errout}
+                         .stderr_ = errout,
+                         .mode_ = Error_Info::Stderr_Found}
                     );
                 }
             }
@@ -474,14 +475,14 @@ void Linter::apply_linters()
             {
                 std::string exc{e.what()};
                 output_dialogue_->add_system_error(
-                    {.mode_ = Error_Info::Bad_Output,
-                     .line_ = e.line(),
-                     .column_ = e.column(),
-                     .message_ = std::wstring(exc.begin(), exc.end()),
+                    {.message_ = std::wstring(exc.begin(), exc.end()),
                      .tool_ = command.program.stem(),
                      .command_ = cmdline,
                      .stdout_ = output,
-                     .stderr_ = errout}
+                     .stderr_ = errout,
+                     .mode_ = Error_Info::Bad_Output,
+                     .line_ = e.line(),
+                     .column_ = e.column()}
                 );
             }
         }
@@ -491,9 +492,9 @@ void Linter::apply_linters()
             // can log
             std::string exc{e.what()};
             output_dialogue_->add_system_error(
-                {.mode_ = Error_Info::Exception,
-                 .message_ = std::wstring(exc.begin(), exc.end()),
-                 .tool_ = command.program.stem()}
+                {.message_ = std::wstring(exc.begin(), exc.end()),
+                 .tool_ = command.program.stem(),
+                 .mode_ = Error_Info::Exception}
             );
         }
     }

--- a/src/linter.cpp
+++ b/src/linter.cpp
@@ -232,7 +232,7 @@ void Linter::highlight_errors()
 {
     clear_error_highlights();
     errors_by_position_.clear();
-    if (! errors_.empty())
+    if (not errors_.empty())
     {
         setup_error_indicator();
     }
@@ -541,7 +541,7 @@ void Linter::show_tooltip(std::wstring message)
             message = L" - ";
         }
 
-        if (! message.empty())
+        if (not message.empty())
         {
 #pragma warning(suppress : 26490)
             ::SendMessage(

--- a/src/linter.h
+++ b/src/linter.h
@@ -81,9 +81,6 @@ class Linter : public Plugin
     // Apply all the applicable linters to the current buffer.
     void apply_linters();
 
-    // Pop up a message on an exception caught when running linters
-    void handle_exception(std::exception const &exc, std::wstring const &tool);
-
     // Shows tooltip in notepad++ window.
     void show_tooltip();
 
@@ -112,7 +109,7 @@ class Linter : public Plugin
     bool file_changed_ = true;
 
     // List of errors picked up in latest lint(s)
-    std::vector<Checkstyle_Parser::Error> errors_;
+    std::vector<Error_Info> errors_;
 
     // Same but by position in window
     std::map<LRESULT, std::wstring> errors_by_position_;

--- a/src/linter.h
+++ b/src/linter.h
@@ -37,7 +37,7 @@ class Linter : public Plugin
     /** Return the plugin name */
     static wchar_t const *get_plugin_name() noexcept;
 
-    Settings const* settings() const noexcept
+    Settings const *settings() const noexcept
     {
         return settings_.get();
     }

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #define WIN32
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 
 #include "targetver.h"
 

--- a/vs2022cpp20.imp
+++ b/vs2022cpp20.imp
@@ -9,5 +9,7 @@
 	{ symbol: ["memcpy", "private", "<string.h>", "public"] },
 	{ symbol: ["std::string_view", "private", "<string_view>", "public"] },
 	{ symbol: ["std::wstring_view", "private", "<string_view>", "public"] },
-	{ symbol: ["_countof", "private", "<vcruntime.h>", "public" ] }
+	{ symbol: ["towlower", "private", "<cwctype>", "public" ] },
+	{ symbol: ["wint_t", "private", "<cwctype>", "public" ] },
+	{ symbol: ["_countof", "private", "<vcruntime.h>", "public" ] },
 ]


### PR DESCRIPTION
1. This will now show the complete stderr/stdout/command line of an error. As part of that, rewrote the stderr/stdout reading code and it now doesn't hang if there's too much output, or, occasionally, randomly decide it had no output.
1. Failure to parse linter++.xml will open the xml file and drop you at the rough location of the error.
1. Reading the first file is no longer so slow.

